### PR TITLE
Fixed moving beacon

### DIFF
--- a/Assets/Prefabs/Gameplay/LevelTools/Collectable.prefab
+++ b/Assets/Prefabs/Gameplay/LevelTools/Collectable.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 1907201016404692514}
   - component: {fileID: 8049567288439223669}
   - component: {fileID: 4665670735767956795}
+  - component: {fileID: 3224535896521598609}
   m_Layer: 0
   m_Name: Pickup Model
   m_TagString: Untagged
@@ -83,6 +84,18 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &3224535896521598609
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 327125991746428290}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dde8fb65895b3c143a3a0f28a872c5d0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &5143591262287150450
 GameObject:
   m_ObjectHideFlags: 0
@@ -220,7 +233,6 @@ GameObject:
   - component: {fileID: 7502911055565795178}
   - component: {fileID: 3257624252997612625}
   - component: {fileID: 9211842386389488402}
-  - component: {fileID: 6604768434168569517}
   m_Layer: 0
   m_Name: Collectable
   m_TagString: Pickup
@@ -278,8 +290,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8ab7ad07c9a7c9f40a9e9bbd5522b044, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _lightPillar: {fileID: 0}
-  _mainCamera: {fileID: 0}
   _collectableData: {fileID: 11400000, guid: 2199cb9728c3b464c9a8f2f12fd3a459, type: 2}
 --- !u!82 &9211842386389488402
 AudioSource:
@@ -377,15 +387,3 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!114 &6604768434168569517
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5336251240345844976}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dde8fb65895b3c143a3a0f28a872c5d0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 


### PR DESCRIPTION
# Description
Fixed the moving beacon bug. The beacon shouldn't move with the collectable dancing now.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Checklist:
Please delete options that are not relevant.

Read this documentation if you're stuck on any area here: https://ccixr-tech.atlassian.net/wiki/spaces/CTD/pages/11010070/Pull+Request+Checklist+Testing

## All Changes (DO NOT DELETE)
- [x] Changes will cause no conflicts.
- [x] Changes have been tested.
- [x] Changes generate no new warnings/errors.
- [x] Changes follow the correct naming conventions & rules.
- [x] Changes don't add unnecessary files.